### PR TITLE
chore: fix a flappy lineage test case

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,10 +1,12 @@
 {
     "cSpell.words": [
         "datahub",
+        "downstreams",
         "Hana",
         "sqlachemy",
         "sqlalchemy",
-        "sqlglot"
+        "sqlglot",
+        "upstreams"
     ],
     "[python]": {
         "editor.tabSize": 4,


### PR DESCRIPTION
Change the test logic so that we check all of the upstream fields and use sorting to ensure the test is stable.